### PR TITLE
feat: add button component

### DIFF
--- a/components/base/Button/Button.tsx
+++ b/components/base/Button/Button.tsx
@@ -1,0 +1,41 @@
+type TButtonSize = 'sm' | 'md' | 'lg' | 'xl' | '2xl';
+type TButtonVariation = 'default' | 'outlined';
+
+const buttonSizes: Record<TButtonSize, string> = {
+  sm: 'text-sm px-[14px] py-2',
+  md: 'text-sm px-4 py-[10px]',
+  lg: 'px-[18px] py-[10px]',
+  xl: 'px-5 py-3',
+  '2xl': 'text-lg px-7 py-4'
+};
+
+const buttonBase = 'font-semibold rounded-lg shadow-sm shadow-primary-100/5';
+
+const buttonStyles: Record<TButtonVariation, string> = {
+  default: `${buttonBase} text-white bg-primary-600 hover:bg-primary-700 focus:ring-4 ring-primary-100 border border-primary-600`,
+  outlined: `${buttonBase} text-black hover:border-gray-400 bg-white focus:ring-4 ring-gray-100 border border-gray-300`
+};
+
+const disabledButtonStyles: Record<TButtonVariation, string> = {
+  default: `${buttonBase} text-white bg-primary-200 hover:bg-primary-200 cursor-not-allowed border border-primary-200`,
+  outlined: `${buttonBase} text-black bg-gray-200 hover:bg-gray-200 border border-gray-300 cursor-not-allowed`
+};
+
+// TODO: Icon
+interface Props extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  size?: TButtonSize;
+  variation?: TButtonVariation;
+}
+
+const Button = ({ className, ...props }: Props) => {
+  const size = buttonSizes[props.size ?? 'md'];
+  let style = props.disabled
+    ? disabledButtonStyles[props.variation ?? 'default']
+    : buttonStyles[props.variation ?? 'default'];
+
+  return (
+    <button {...props} className={[size, style, className].join(' ').trim()} />
+  );
+};
+
+export default Button;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -11,6 +11,16 @@ module.exports = {
     extend: {
       fontFamily: {
         sans: ['var(--font-inter)', ...fontFamily.sans]
+      },
+      colors: {
+        primary: {
+          50: '#F9F5FF',
+          100: '#F4EBFF',
+          200: '#E9D7FE',
+          500: '#9E77ED',
+          600: '#7F56D9',
+          700: '#6941C6'
+        }
       }
     }
   },


### PR DESCRIPTION
#22 

Since there is no example implementation of tailwind in the repo currently, I did it on my own way. I can replace it  with the desired way if needed.

## What this pr does
- [x] Reusable button component
  - Props extends React's `HTMLButtonElement` to be able to reach all the attributes when necessary. (*Can narrow it if it's unwanted*)
- [x] Add primary colors to tailwind config. (*I was unable to get other tints of the primary color from figma for some reason*)