### PR TITLE
feat: add avatar component

### DIFF
--- a/components/Avatar/constants.ts
+++ b/components/Avatar/constants.ts
@@ -1,0 +1,8 @@
+export const SIZES = {
+  xs: 24,
+  sm: 32,
+  md: 40,
+  lg: 48,
+  xl: 56,
+  '2xl': 64
+};

--- a/components/Avatar/index.tsx
+++ b/components/Avatar/index.tsx
@@ -1,0 +1,27 @@
+import Image, { ImageProps } from 'next/image';
+import { twMerge } from 'tailwind-merge';
+
+import { SIZES } from './constants';
+
+interface Props extends ImageProps {
+  className?: string;
+  size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl';
+  src: string;
+  alt: string;
+}
+
+const Avatar = ({ className, size = 'md', src, alt, ...props }: Props) => (
+  <Image
+    {...props}
+    src={src}
+    alt={alt}
+    width={SIZES[size]}
+    height={SIZES[size]}
+    className={twMerge(
+      className,
+      'box-content rounded-full border-4 border-transparent transition-colors hover:border-violet-100'
+    )}
+  />
+);
+
+export default Avatar;

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "rehype-pretty-code": "^0.3.2",
         "rehype-slug": "^5.1.0",
         "shiki": "^0.11.1",
+        "tailwind-merge": "^1.8.1",
         "typescript": "4.9.3"
       },
       "devDependencies": {
@@ -6714,6 +6715,11 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
       "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
+    "node_modules/tailwind-merge": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-1.8.1.tgz",
+      "integrity": "sha512-+fflfPxvHFr81hTJpQ3MIwtqgvefHZFUHFiIHpVIRXvG/nX9+gu2P7JNlFu2bfDMJ+uHhi/pUgzaYacMoXv+Ww=="
+    },
     "node_modules/tailwindcss": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.2.4.tgz",
@@ -11895,6 +11901,11 @@
           "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
         }
       }
+    },
+    "tailwind-merge": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-1.8.1.tgz",
+      "integrity": "sha512-+fflfPxvHFr81hTJpQ3MIwtqgvefHZFUHFiIHpVIRXvG/nX9+gu2P7JNlFu2bfDMJ+uHhi/pUgzaYacMoXv+Ww=="
     },
     "tailwindcss": {
       "version": "3.2.4",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "rehype-pretty-code": "^0.3.2",
     "rehype-slug": "^5.1.0",
     "shiki": "^0.11.1",
+    "tailwind-merge": "^1.8.1",
     "typescript": "4.9.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Added [tailwind-merge](https://www.npmjs.com/package/tailwind-merge) package to avoid repeating and missing the default style in extra style. `violet-100` was used because the equivalent of the `primary-100` value used by Figma is not in the tailwind default colors.

Issue: #20